### PR TITLE
Calculate earned rewards optimization

### DIFF
--- a/Sources/Catch/Models/DonationRecipient.swift
+++ b/Sources/Catch/Models/DonationRecipient.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct DonationRecipient: Codable {
+struct DonationRecipient: Codable, Equatable {
     let name: String
     let url: String
 }

--- a/Sources/Catch/Models/EarnedRewardRuleDetail.swift
+++ b/Sources/Catch/Models/EarnedRewardRuleDetail.swift
@@ -7,15 +7,15 @@
 
 import Foundation
 
-struct EarnedRewardRuleDetail: Codable {
-    let rewardRuleId: String
-    let earnedRewardAmount: Int
-    let userFacingName: String?
-    let rewardAmountType: String?
-    let ruleEngineType: String?
-    let flatRewardAmount: Int?
-    let percentageRewardRate: Double?
-    let rewardType: String?
-    let detailsLink: String?
-    let sortOrder: Int?
+struct EarnedRewardRuleDetail: Codable, Equatable {
+    var rewardRuleId: String
+    var earnedRewardAmount: Int
+    var userFacingName: String?
+    var rewardAmountType: String?
+    var ruleEngineType: String?
+    var flatRewardAmount: Int?
+    var percentageRewardRate: Double?
+    var rewardType: String?
+    var detailsLink: String?
+    var sortOrder: Int?
 }

--- a/Sources/Catch/Models/Merchant+DefaultRewards.swift
+++ b/Sources/Catch/Models/Merchant+DefaultRewards.swift
@@ -1,0 +1,61 @@
+//
+//  Merchant+DefaultRewards.swift
+//  
+//
+//  Created by Lucille Benoit on 12/23/22.
+//
+
+import Foundation
+
+/**
+ Extension to generate the default earned rewards summary for a merchant.
+ */
+extension Merchant {
+    private var newCatchUserRewardRule: EarnedRewardRuleDetail {
+        return EarnedRewardRuleDetail(
+            rewardRuleId: newCatchUserRewardRuleId,
+            earnedRewardAmount: defaultSignUpBonus,
+            userFacingName: RewardType.newCatchUserRewardRuleUserFacingName,
+            rewardAmountType: RewardType.flatRewardAmountType,
+            ruleEngineType: RewardType.newCatchUserRuleEngineType,
+            flatRewardAmount: defaultSignUpBonus
+        )
+    }
+
+    private func unrestrictedEarnedRewardRule(price: Int,
+                                              userRewardAmount: Int) -> EarnedRewardRuleDetail {
+        let amountEligibleForEarnedRewards = max(price-userRewardAmount, 0)
+        let unrestrictedEarnedRewardAmount = Int(
+            ceil(Double(amountEligibleForEarnedRewards) * defaultEarnedRewardsRate)
+        )
+
+        return EarnedRewardRuleDetail(
+            rewardRuleId: unrestrictedRewardRuleId,
+            earnedRewardAmount: unrestrictedEarnedRewardAmount,
+            userFacingName: RewardType.unrestrictedRewardRuleUserFacingName,
+            rewardAmountType: RewardType.percentageRewardAmountType,
+            ruleEngineType: RewardType.unrestrictedRuleEngineType,
+            percentageRewardRate: defaultEarnedRewardsRate
+        )
+    }
+
+    func generateCalculatedRewards(price: Int,
+                                   userRewardAmount: Int,
+                                   firstPurchaseBonusEligibility: Bool) -> EarnedRewardsSummary {
+        let unrestrictedEarnedRewardBreakdown = unrestrictedEarnedRewardRule(price: price,
+                                                                             userRewardAmount: userRewardAmount)
+        var earnedRewardBreakdownList: [EarnedRewardRuleDetail] = [unrestrictedEarnedRewardBreakdown]
+
+        if firstPurchaseBonusEligibility {
+            earnedRewardBreakdownList += [newCatchUserRewardRule]
+        }
+
+        let earnedRewardsTotal = earnedRewardBreakdownList.sum(\.earnedRewardAmount)
+
+        return EarnedRewardsSummary(signUpBonusAmount: defaultSignUpBonus,
+                                    signUpDiscountAmount: defaultSignUpDiscount,
+                                    percentageRewardRate: defaultEarnedRewardsRate,
+                                    earnedRewardsTotal: earnedRewardsTotal,
+                                    earnedRewardBreakdown: earnedRewardBreakdownList)
+    }
+}

--- a/Sources/Catch/Models/Merchant.swift
+++ b/Sources/Catch/Models/Merchant.swift
@@ -21,6 +21,9 @@ struct Merchant: Codable, Equatable {
     /// Between 0 and 1, the fraction of amount paid that a user gets back at this merchant.
     let defaultEarnedRewardsRate: Double
 
+    /// Flag determining if merchant uses configurable rewards.
+    let enableConfigurableRewards: Bool
+
     /// Number of days after earning that the rewards expire.
     let rewardsLifetimeInDays: Int
 
@@ -42,16 +45,14 @@ struct Merchant: Codable, Equatable {
     /// Flat amount that a new Catch user will receive as a discount at this merchant
     let defaultSignUpDiscount: Int
 
+    /// ID corresponding to the currently active unrestricted reward rule with the highest percentage
+    let unrestrictedRewardRuleId: String
+
+    /// ID corresponding to the currently active new catch user reward rule with the highest amount
+    let newCatchUserRewardRuleId: String
+
     /// Theme for web views
     let theme: MerchantThemeConfig?
-
-    static func == (lhs: Merchant, rhs: Merchant) -> Bool {
-        return lhs.merchantId == rhs.merchantId
-        && lhs.name == rhs.name
-        && lhs.url == rhs.url
-        && lhs.defaultEarnedRewardsRate == rhs.defaultEarnedRewardsRate
-        && lhs.rewardsLifetimeInDays == rhs.rewardsLifetimeInDays
-    }
 
     /// The expiration date as calculated by using the current date and the merchant's rewards lifetime.
     var expirationDate: Date? {
@@ -59,6 +60,6 @@ struct Merchant: Codable, Equatable {
     }
 }
 
-struct MerchantThemeConfig: Codable {
+struct MerchantThemeConfig: Codable, Equatable {
     let name: String
 }

--- a/Sources/Catch/Models/Tofu/MerchantDefaults.swift
+++ b/Sources/Catch/Models/Tofu/MerchantDefaults.swift
@@ -14,10 +14,12 @@ struct MerchantDefaults: Encodable {
     let defaultEarnedRewardsRate: Double
     let defaultSignUpBonus: Int
     let defaultSignUpDiscount: Int
+    let enableConfigurableRewards: Bool
 
     init(merchant: Merchant) {
         self.defaultEarnedRewardsRate = merchant.defaultEarnedRewardsRate
         self.defaultSignUpBonus = merchant.defaultSignUpBonus
         self.defaultSignUpDiscount = merchant.defaultSignUpDiscount
+        self.enableConfigurableRewards = merchant.enableConfigurableRewards
     }
 }

--- a/Sources/Catch/Utilities/Enums/RewardType.swift
+++ b/Sources/Catch/Utilities/Enums/RewardType.swift
@@ -1,0 +1,20 @@
+//
+//  RewardType.swift
+//  
+//
+//  Created by Lucille Benoit on 12/23/22.
+//
+
+import Foundation
+
+/**
+ Reward types used to generate default merchant rewards summaries.
+ */
+enum RewardType {
+    static let unrestrictedRewardRuleUserFacingName = "on every order"
+    static let unrestrictedRuleEngineType = "unrestricted"
+    static let newCatchUserRewardRuleUserFacingName = "First order boost"
+    static let newCatchUserRuleEngineType = "new_catch_user"
+    static let percentageRewardAmountType = "percentage"
+    static let flatRewardAmountType = "flat"
+}

--- a/Sources/Catch/Utilities/Sequence+Extension.swift
+++ b/Sources/Catch/Utilities/Sequence+Extension.swift
@@ -1,0 +1,13 @@
+//
+//  Sequence+Extension.swift
+//  
+//
+//  Created by Lucille Benoit on 12/23/22.
+//
+
+import Foundation
+
+extension Sequence {
+    // Sum of a property across objects in an array (ex. arr.sum(\.amount))
+    func sum<T: AdditiveArithmetic>(_ predicate: (Element) -> T) -> T { reduce(.zero) { $0 + predicate($1) } }
+}

--- a/Tests/CatchTests/MerchantDefaultRewardsTests.swift
+++ b/Tests/CatchTests/MerchantDefaultRewardsTests.swift
@@ -1,0 +1,91 @@
+//
+//  MerchantDefaultRewardsTests.swift
+//  
+//
+//  Created by Lucille Benoit on 12/23/22.
+//
+
+import Foundation
+
+import XCTest
+@testable import Catch
+
+final class MerchantDefaultRewardsTests: XCTestCase {
+    let price = 2000
+    let userRewardAmount = 200
+    let merchant = MockDataProvider.defaultMerchant
+
+    // Test default calculated merchant rewards for a user not eligible for the first purchase bonus
+    func testDefaultRewardsReturningUser() {
+        let defaultRewardSummary = merchant.generateCalculatedRewards(price: price,
+                                                                userRewardAmount: userRewardAmount,
+                                                                firstPurchaseBonusEligibility: false)
+        let amountEligibleForEarnedRewards = max(price-userRewardAmount, 0)
+        let unrestrictedEarnedRewardAmount = Int(
+            ceil(Double(amountEligibleForEarnedRewards) * merchant.defaultEarnedRewardsRate)
+        )
+
+        let expectedRewardRuleDetail = EarnedRewardRuleDetail(
+            rewardRuleId: merchant.unrestrictedRewardRuleId,
+            earnedRewardAmount: unrestrictedEarnedRewardAmount,
+            userFacingName: RewardType.unrestrictedRewardRuleUserFacingName,
+            rewardAmountType: RewardType.percentageRewardAmountType,
+            ruleEngineType: RewardType.unrestrictedRuleEngineType,
+            percentageRewardRate: merchant.defaultEarnedRewardsRate
+        )
+
+        // Validate that merchant default bonuses exist on the earned rewards summary
+        XCTAssertEqual(defaultRewardSummary.signUpBonusAmount, merchant.defaultSignUpBonus)
+        XCTAssertEqual(defaultRewardSummary.signUpDiscountAmount, merchant.defaultSignUpDiscount)
+        XCTAssertEqual(defaultRewardSummary.percentageRewardRate, merchant.defaultEarnedRewardsRate)
+
+        // The total reward should equal the unrestricted earned reward amount
+        XCTAssertEqual(defaultRewardSummary.earnedRewardsTotal, expectedRewardRuleDetail.earnedRewardAmount)
+
+        // Earned reward breakdown should only include the unrestricted reward rule detail
+        XCTAssertEqual(defaultRewardSummary.earnedRewardBreakdown, [expectedRewardRuleDetail])
+    }
+
+    // Test default calculated merchant rewards for a user eligible for the first purchase bonus
+    func testDefaultRewardsFirstTimeUser() {
+        let defaultRewardSummary = merchant.generateCalculatedRewards(price: price,
+                                                                userRewardAmount: userRewardAmount,
+                                                                firstPurchaseBonusEligibility: true)
+        let amountEligibleForEarnedRewards = max(price-userRewardAmount, 0)
+        let unrestrictedEarnedRewardAmount = Int(
+            ceil(Double(amountEligibleForEarnedRewards) * merchant.defaultEarnedRewardsRate)
+        )
+
+        let expectedUnrestrictedRewardRule = EarnedRewardRuleDetail(
+            rewardRuleId: merchant.unrestrictedRewardRuleId,
+            earnedRewardAmount: unrestrictedEarnedRewardAmount,
+            userFacingName: RewardType.unrestrictedRewardRuleUserFacingName,
+            rewardAmountType: RewardType.percentageRewardAmountType,
+            ruleEngineType: RewardType.unrestrictedRuleEngineType,
+            percentageRewardRate: merchant.defaultEarnedRewardsRate
+        )
+
+        let expectedNewCatchUserRewardRule = EarnedRewardRuleDetail(
+            rewardRuleId: merchant.newCatchUserRewardRuleId,
+            earnedRewardAmount: merchant.defaultSignUpBonus,
+            userFacingName: RewardType.newCatchUserRewardRuleUserFacingName,
+            rewardAmountType: RewardType.flatRewardAmountType,
+            ruleEngineType: RewardType.newCatchUserRuleEngineType,
+            flatRewardAmount: merchant.defaultSignUpBonus
+        )
+
+        // Validate that merchant default bonuses exist on the earned rewards summary
+        XCTAssertEqual(defaultRewardSummary.signUpBonusAmount, merchant.defaultSignUpBonus)
+        XCTAssertEqual(defaultRewardSummary.signUpDiscountAmount, merchant.defaultSignUpDiscount)
+        XCTAssertEqual(defaultRewardSummary.percentageRewardRate, merchant.defaultEarnedRewardsRate)
+
+        // The total reward should equal the unrestricted earned reward amount plus the new user reward amount
+        let expectedTotal = expectedUnrestrictedRewardRule.earnedRewardAmount
+        + expectedNewCatchUserRewardRule.earnedRewardAmount
+        XCTAssertEqual(defaultRewardSummary.earnedRewardsTotal, expectedTotal)
+
+        // The reward breakdown should include both the unrestricted reward rule and the new user reward rule
+        let expectedBreakdown = [expectedUnrestrictedRewardRule, expectedNewCatchUserRewardRule]
+        XCTAssertEqual(defaultRewardSummary.earnedRewardBreakdown, expectedBreakdown)
+    }
+}

--- a/Tests/CatchTests/Mock Objects/MockDataProvider.swift
+++ b/Tests/CatchTests/Mock Objects/MockDataProvider.swift
@@ -19,6 +19,7 @@ class MockDataProvider {
                         name: "Test Merchant",
                         url: "www.google.com",
                         defaultEarnedRewardsRate: 0.1,
+                        enableConfigurableRewards: true,
                         rewardsLifetimeInDays: 180,
                         cardBackgroundImageUrl: imageURL,
                         cardBackgroundColor: "#C779D0",
@@ -26,6 +27,8 @@ class MockDataProvider {
                         donationRecipient: nil,
                         defaultSignUpBonus: 1000,
                         defaultSignUpDiscount: 0,
+                        unrestrictedRewardRuleId: "unrestrictedId",
+                        newCatchUserRewardRuleId: "newCatchUserId",
                         theme: nil)
     }
 


### PR DESCRIPTION
### Summary
Modifies the `RewardsCalculator` to only call the get calculate earned rewards endpoint if the merchant has `enableConfigurableRewards` as `true`. 

Otherwise, rewards will be calculated locally using the price, existing user reward amount, and merchant's default values. The logic for calculating earned rewards locally is found in `generateCalculatedRewards` in `Merchant+DefaultRewards.swift` and mirrors the logic that currently exists on [web](https://github.com/getcatch/catch-frontend-common/blob/327c067dce886d1b5f7468d8cb589cf5568b702d/utils/configurable-rewards.ts#L116).

### Relevant Ticket
Closes MER-880