### PR TITLE
Github action for publishing documentation to pages

### DIFF
--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -1,0 +1,44 @@
+name: Deploy DocC
+
+on:
+  push:
+    branches: ["main"]
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: macos-12
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
+      - name: Build DocC
+        run: |
+          xcodebuild docbuild -scheme Catch \
+            -derivedDataPath /tmp/docbuild \
+            -destination 'generic/platform=iOS';
+          $(xcrun --find docc) process-archive \
+            transform-for-static-hosting /tmp/docbuild/Build/Products/Debug-iphoneos/Catch.doccarchive \
+            --hosting-base-path catch-ios-sdk \
+            --output-path docs;
+          echo "<script>window.location.href += \"/documentation/catch\"</script>" > docs/index.html;
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          # Upload only docs directory
+          path: 'docs'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/Sources/Catch/Catch.docc/Catch.md
+++ b/Sources/Catch/Catch.docc/Catch.md
@@ -246,5 +246,5 @@ After (2), the SDK will close the checkout flow and call the `onCancel` callback
 - ``Price``
 - ``Item``
 - ``Platform``
-- ``CardDetails``
+- ``VirtualCardDetails``
 - ``CreateVirtualCardCheckoutBody``


### PR DESCRIPTION
### Summary

Creates a Github action which will regenerate the documentation on every push to `main` and publish the documentation on Github pages.

### Relevant Tickets
Closes MER-961