### PR TITLE
Widget text style refactor

### DIFF
--- a/Example/Example/Demo Views/CalloutDemo.swift
+++ b/Example/Example/Demo Views/CalloutDemo.swift
@@ -17,7 +17,7 @@ class CalloutDemo: WidgetDemo {
         return [label, widgetStack, configurationStack]
     }
 
-    var calloutView = Callout(price: 0, borderStyle: .pill, styleOverrides: <#T##InfoWidgetStyle?#>)
+    var calloutView = Callout(price: 0, borderStyle: .pill)
 
     init() {
         super.init(title: Strings.calloutName, widget: calloutView)

--- a/Example/Example/Demo Views/CalloutDemo.swift
+++ b/Example/Example/Demo Views/CalloutDemo.swift
@@ -17,8 +17,7 @@ class CalloutDemo: WidgetDemo {
         return [label, widgetStack, configurationStack]
     }
 
-    var
-    calloutView = Callout(price: 0, borderStyle: .pill)
+    var calloutView = Callout(price: 0, borderStyle: .pill, styleOverrides: <#T##InfoWidgetStyle?#>)
 
     init() {
         super.init(title: Strings.calloutName, widget: calloutView)

--- a/Sources/Catch/Catch.docc/Catch.md
+++ b/Sources/Catch/Catch.docc/Catch.md
@@ -227,7 +227,6 @@ After (2), the SDK will close the checkout flow and call the `onCancel` callback
 - ``InfoWidgetStyle``
 - ``TextStyle``
 - ``BenefitTextStyle``
-- ``WidgetTextStyle``
 - ``TextTransform``
 - ``ActionButtonStyle``
 - ``BorderStyle``

--- a/Sources/Catch/Utilities/Enums/Theme.swift
+++ b/Sources/Catch/Utilities/Enums/Theme.swift
@@ -100,9 +100,9 @@ public enum Theme {
                          font: CatchFont.link(size: size))
     }
 
-    internal func widgetTextStyle(size: CatchFont.Size) -> WidgetTextStyle {
-        return WidgetTextStyle(textStyle: textStyle(size: size),
-                               benefitTextStyle: benefitTextStyle(size: size))
+    internal func earnRedeemLabelStyle(size: CatchFont.Size) -> EarnRedeemLabelStyle {
+        return EarnRedeemLabelStyle(textStyle: textStyle(size: size),
+                                    benefitTextStyle: benefitTextStyle(size: size))
     }
 
     internal var infoButtonStyle: TextStyle {
@@ -120,11 +120,15 @@ public enum Theme {
     }
 
     internal func infoWidgetStyle(textSize: CatchFont.Size) -> InfoWidgetStyle {
-        InfoWidgetStyle(widgetTextStyle: widgetTextStyle(size: textSize), infoButtonStyle: infoButtonStyle)
+        InfoWidgetStyle(textStyle: textStyle(size: textSize),
+                        benefitTextStyle: benefitTextStyle(size: textSize),
+                        infoButtonStyle: infoButtonStyle)
     }
 
     internal var actionWidgetStyle: ActionWidgetStyle {
-        ActionWidgetStyle(widgetTextStyle: widgetTextStyle(size: .large), actionButtonStyle: actionButtonStyle)
+        ActionWidgetStyle(textStyle: textStyle(size: .large),
+                          benefitTextStyle: benefitTextStyle(size: .large),
+                          actionButtonStyle: actionButtonStyle)
     }
 
     internal func styleDefaultForWidgetType(_ type: StyleResolver.WidgetType) -> WidgetStyle? {

--- a/Sources/Catch/Utilities/Styling/ActionWidgetStyle.swift
+++ b/Sources/Catch/Utilities/Styling/ActionWidgetStyle.swift
@@ -8,8 +8,15 @@
 import Foundation
 
 protocol WidgetStyle {
-    var widgetTextStyle: WidgetTextStyle? { get set }
+    var textStyle: TextStyle? { get set }
+    var benefitTextStyle: BenefitTextStyle? { get set }
     var type: WidgetStyleType { get }
+}
+
+extension WidgetStyle {
+    func earnRedeemLabelStyle() -> EarnRedeemLabelStyle {
+        return EarnRedeemLabelStyle(textStyle: textStyle, benefitTextStyle: benefitTextStyle)
+    }
 }
 
 enum WidgetStyleType {
@@ -27,26 +34,34 @@ enum WidgetStyleType {
 public struct ActionWidgetStyle: WidgetStyle {
     internal var type: WidgetStyleType = .actionWidget
 
-    /// Configures the styling of text components within the widget.
-    var widgetTextStyle: WidgetTextStyle?
+    /// Configures text attributes for all elements within a Catch widget
+    var textStyle: TextStyle?
+
+    /// Configures the colors and font specifically for the benefit text (ex. "Earn x% credit")
+    /// All other text attributes will be inherited from the textStyle.
+    var benefitTextStyle: BenefitTextStyle?
 
     /// Configures the styling of the action button within the widget.
     var actionButtonStyle: ActionButtonStyle?
 
     /**
      Initializes an ``ActionWidgetStyle`` configuration.
-     - Parameter widgetTextStyle: the styling of text components within the widget (see ``WidgetTextStyle``).
+     - Parameter textStyle: the styling of text components within the widget (see ``TextStyle``).
+     - Parameter benefitTextStyle: the styling for the benefit text within Catch widgets. ( see ``BenefitTextStyle``).
      - Parameter actionButtonStyle: the styling of the action button within the widget (see ``ActionButtonStyle``).
      */
-    public init(widgetTextStyle: WidgetTextStyle? = nil, actionButtonStyle: ActionButtonStyle? = nil) {
-        self.widgetTextStyle = widgetTextStyle
+    public init(textStyle: TextStyle? = nil, benefitTextStyle: BenefitTextStyle? = nil, actionButtonStyle: ActionButtonStyle? = nil) {
+        self.textStyle = textStyle
+        self.benefitTextStyle = benefitTextStyle
         self.actionButtonStyle = actionButtonStyle
     }
 
     internal static func resolved(_ style: ActionWidgetStyle?,
                                   withOverrides overrides: ActionWidgetStyle?) -> ActionWidgetStyle? {
-        ActionWidgetStyle(widgetTextStyle: WidgetTextStyle.resolved(style?.widgetTextStyle,
-                                                                    withOverrides: overrides?.widgetTextStyle),
+        ActionWidgetStyle(textStyle: TextStyle.resolved(style?.textStyle,
+                                                        withOverrides: overrides?.textStyle),
+                          benefitTextStyle: BenefitTextStyle.resolved(style?.benefitTextStyle,
+                                                                      withOverrides: overrides?.benefitTextStyle),
                           actionButtonStyle: ActionButtonStyle.resolved(style?.actionButtonStyle,
                                                                         withOverrides: overrides?.actionButtonStyle))
 

--- a/Sources/Catch/Utilities/Styling/ActionWidgetStyle.swift
+++ b/Sources/Catch/Utilities/Styling/ActionWidgetStyle.swift
@@ -50,7 +50,9 @@ public struct ActionWidgetStyle: WidgetStyle {
      - Parameter benefitTextStyle: the styling for the benefit text within Catch widgets. ( see ``BenefitTextStyle``).
      - Parameter actionButtonStyle: the styling of the action button within the widget (see ``ActionButtonStyle``).
      */
-    public init(textStyle: TextStyle? = nil, benefitTextStyle: BenefitTextStyle? = nil, actionButtonStyle: ActionButtonStyle? = nil) {
+    public init(textStyle: TextStyle? = nil,
+                benefitTextStyle: BenefitTextStyle? = nil,
+                actionButtonStyle: ActionButtonStyle? = nil) {
         self.textStyle = textStyle
         self.benefitTextStyle = benefitTextStyle
         self.actionButtonStyle = actionButtonStyle

--- a/Sources/Catch/Utilities/Styling/CatchStyleConfig.swift
+++ b/Sources/Catch/Utilities/Styling/CatchStyleConfig.swift
@@ -44,10 +44,6 @@ public struct CatchStyleConfig {
     /// Configures the styling for all campaign link widgets
     var campaignLinkStyle: ActionWidgetStyle?
 
-    internal var widgetTextStyles: WidgetTextStyle {
-        return WidgetTextStyle(textStyle: textStyle, benefitTextStyle: benefitTextStyle)
-    }
-
     /**
      Initializes a global style config for the Catch widgets.
      - Parameter textStyle: The styling for all text components globally (see ``TextStyle``).
@@ -111,9 +107,13 @@ public struct CatchStyleConfig {
     internal func universalConfigForWidget(_ type: StyleResolver.WidgetType) -> WidgetStyle {
         switch type {
         case .callout, .expressCheckoutCallout, .paymentMethod:
-            return InfoWidgetStyle(widgetTextStyle: widgetTextStyles, infoButtonStyle: infoButtonStyle)
+            return InfoWidgetStyle(textStyle: textStyle,
+                                   benefitTextStyle: benefitTextStyle,
+                                   infoButtonStyle: infoButtonStyle)
         case .purchaseConfirmation, .campaignLink:
-            return ActionWidgetStyle(widgetTextStyle: widgetTextStyles, actionButtonStyle: actionButtonStyle)
+            return ActionWidgetStyle(textStyle: textStyle,
+                                     benefitTextStyle: benefitTextStyle,
+                                     actionButtonStyle: actionButtonStyle)
         }
     }
 }

--- a/Sources/Catch/Utilities/Styling/EarnRedeemLabelStyle.swift
+++ b/Sources/Catch/Utilities/Styling/EarnRedeemLabelStyle.swift
@@ -1,5 +1,5 @@
 //
-//  WidgetTextStyle.swift
+//  EarnRedeemLabelStyle.swift
 //  Catch
 //
 //  Created by Lucille Benoit on 12/4/22.
@@ -8,12 +8,12 @@
 import UIKit
 
 /**
- The text style set for Catch widgets.
+ The text style set for Earn Redeem Labels.
 
  This includes the general text styling (see ``TextStyle``) as well as
  configurations specific to the benefit text components (see ``BenefitTextStyle``).
  */
-public struct WidgetTextStyle {
+struct EarnRedeemLabelStyle {
     /// Configures text attributes for all elements within a Catch widget
     var textStyle: TextStyle?
 
@@ -21,7 +21,7 @@ public struct WidgetTextStyle {
     /// All other text attributes will be inherited from the textStyle.
     var benefitTextStyle: BenefitTextStyle?
 
-    /// Initializes a WidgetTextStyle configuration.
+    /// Initializes an EarnRedeemLabelStyle configuration.
     public init(textStyle: TextStyle? = nil, benefitTextStyle: BenefitTextStyle? = nil) {
         self.textStyle = textStyle
         self.benefitTextStyle = benefitTextStyle
@@ -50,12 +50,5 @@ public struct WidgetTextStyle {
             return benefitStyle
         }
         return nil
-    }
-
-    internal static func resolved(_ style: WidgetTextStyle?,
-                                  withOverrides overrides: WidgetTextStyle?) -> WidgetTextStyle {
-        WidgetTextStyle(textStyle: TextStyle.resolved(style?.textStyle, withOverrides: overrides?.textStyle),
-                        benefitTextStyle: BenefitTextStyle.resolved(style?.benefitTextStyle,
-                                                                    withOverrides: overrides?.benefitTextStyle))
     }
 }

--- a/Sources/Catch/Utilities/Styling/InfoWidgetStyle.swift
+++ b/Sources/Catch/Utilities/Styling/InfoWidgetStyle.swift
@@ -34,7 +34,9 @@ public struct InfoWidgetStyle: WidgetStyle {
      - Parameter benefitTextStyle: the styling for the benefit text within Catch widgets. ( see ``BenefitTextStyle``).
      - Parameter infoButtonStyle: the styling of the info button within the widget.
      */
-    public init(textStyle: TextStyle? = nil, benefitTextStyle: BenefitTextStyle? = nil, infoButtonStyle: TextStyle? = nil) {
+    public init(textStyle: TextStyle? = nil,
+                benefitTextStyle: BenefitTextStyle? = nil,
+                infoButtonStyle: TextStyle? = nil) {
         self.textStyle = textStyle
         self.benefitTextStyle = benefitTextStyle
         self.infoButtonStyle = infoButtonStyle

--- a/Sources/Catch/Utilities/Styling/InfoWidgetStyle.swift
+++ b/Sources/Catch/Utilities/Styling/InfoWidgetStyle.swift
@@ -18,28 +18,36 @@ import Foundation
 public struct InfoWidgetStyle: WidgetStyle {
     internal var type: WidgetStyleType = .labelWidget
 
-    /// Configures the styling of text components within the widget.
-    var widgetTextStyle: WidgetTextStyle?
+    /// Configures text attributes for all elements within a Catch widget
+    var textStyle: TextStyle?
+
+    /// Configures the colors and font specifically for the benefit text (ex. "Earn x% credit")
+    /// All other text attributes will be inherited from the textStyle.
+    var benefitTextStyle: BenefitTextStyle?
 
     /// Configures the styling of the info button within the widget.
     var infoButtonStyle: TextStyle?
 
     /**
      Initializes a ``InfoWidgetStyle`` configuration.
-     - Parameter widgetTextStyle: the styling of text components within the widget.
+     - Parameter textStyle: the styling of text components within the widget (see ``TextStyle``).
+     - Parameter benefitTextStyle: the styling for the benefit text within Catch widgets. ( see ``BenefitTextStyle``).
      - Parameter infoButtonStyle: the styling of the info button within the widget.
      */
-    public init(widgetTextStyle: WidgetTextStyle? = nil, infoButtonStyle: TextStyle? = nil) {
-        self.widgetTextStyle = widgetTextStyle
+    public init(textStyle: TextStyle? = nil, benefitTextStyle: BenefitTextStyle? = nil, infoButtonStyle: TextStyle? = nil) {
+        self.textStyle = textStyle
+        self.benefitTextStyle = benefitTextStyle
         self.infoButtonStyle = infoButtonStyle
     }
 
     internal static func resolved(_ style: InfoWidgetStyle?,
                                   withOverrides overrides: InfoWidgetStyle?) -> InfoWidgetStyle? {
-        return InfoWidgetStyle(widgetTextStyle: WidgetTextStyle.resolved(style?.widgetTextStyle,
-                                                                          withOverrides: overrides?.widgetTextStyle),
-                                infoButtonStyle: TextStyle.resolved(style?.infoButtonStyle,
-                                                                    withOverrides: overrides?.infoButtonStyle))
+        return InfoWidgetStyle(textStyle: TextStyle.resolved(style?.textStyle,
+                                                             withOverrides: overrides?.textStyle),
+                               benefitTextStyle: BenefitTextStyle.resolved(style?.benefitTextStyle,
+                                                                           withOverrides: overrides?.benefitTextStyle),
+                               infoButtonStyle: TextStyle.resolved(style?.infoButtonStyle,
+                                                                   withOverrides: overrides?.infoButtonStyle))
     }
 
     internal static func defaults(theme: Theme?, widgetType: StyleResolver.WidgetType) -> InfoWidgetStyle? {

--- a/Sources/Catch/Views/Callout.swift
+++ b/Sources/Catch/Views/Callout.swift
@@ -109,7 +109,7 @@ public class Callout: _BaseEarnRedeemWidget {
 
     override public func layoutSubviews() {
         // Split the stack into two lines if content width is larger than available width
-        needsMultiLineLayout = (contentWidth() > frame.width)
+        needsMultiLineLayout = (contentWidth() > frame.width + 1)
 
         // Configure two line layout if stack is not yet vertical
         if needsMultiLineLayout && stack.axis != .vertical {

--- a/Sources/Catch/Views/Components/BaseCardWidget.swift
+++ b/Sources/Catch/Views/Components/BaseCardWidget.swift
@@ -106,8 +106,8 @@ public class _BaseCardWidget: _BaseWidget {
         externalLinkButton.setStyle(style: buttonStyle)
     }
 
-    override internal func createBenefitTextStyle() -> WidgetTextStyle {
-        resolvedActionWidgetStyling?.widgetTextStyle ?? theme.widgetTextStyle(size: .large)
+    override internal func createBenefitTextStyle() -> EarnRedeemLabelStyle {
+        resolvedActionWidgetStyling?.earnRedeemLabelStyle() ?? theme.earnRedeemLabelStyle(size: .large)
     }
 
     /**

--- a/Sources/Catch/Views/Components/BaseWidget.swift
+++ b/Sources/Catch/Views/Components/BaseWidget.swift
@@ -14,7 +14,7 @@ public class _BaseWidget: UIView, NotificationResponding, BorderConfiguring, Bas
     internal let stack: UIStackView = UIStackView()
     internal var logo: CatchLogo
     lazy internal var label: EarnRedeemLabel = EarnRedeemLabel(type: earnRedeemLabelType,
-                                                               style: theme.widgetTextStyle(size: .small),
+                                                               style: theme.earnRedeemLabelStyle(size: .small),
                                                                tapHandler: didTapEarnRedeemLabel)
     internal var earnRedeemLabelType: EarnRedeemLabelType
 
@@ -104,8 +104,8 @@ public class _BaseWidget: UIView, NotificationResponding, BorderConfiguring, Bas
         logo.setTheme(theme)
     }
 
-    internal func createBenefitTextStyle() -> WidgetTextStyle {
-        return resolvedStyling?.widgetTextStyle ?? theme.widgetTextStyle(size: .small)
+    internal func createBenefitTextStyle() -> EarnRedeemLabelStyle {
+        return resolvedStyling?.earnRedeemLabelStyle() ?? theme.earnRedeemLabelStyle(size: .small)
     }
 
     // MARK: - AutoLayout

--- a/Sources/Catch/Views/Components/EarnRedeemLabel.swift
+++ b/Sources/Catch/Views/Components/EarnRedeemLabel.swift
@@ -24,7 +24,7 @@ class EarnRedeemLabel: UILabel, Skeletonizable {
     }
     private var type: EarnRedeemLabelType
 
-    internal var style: WidgetTextStyle {
+    internal var style: EarnRedeemLabelStyle {
         didSet {
             updateAttributedString()
         }
@@ -60,7 +60,7 @@ class EarnRedeemLabel: UILabel, Skeletonizable {
      - Parameter tapHandler: The callback function to be called when the link is tapped.
      */
     init(type: EarnRedeemLabelType,
-         style: WidgetTextStyle,
+         style: EarnRedeemLabelStyle,
          tapHandler: @escaping () -> Void) {
         self.type = type
         self.style = style

--- a/Sources/Catch/Views/ExpressCheckoutCallout.swift
+++ b/Sources/Catch/Views/ExpressCheckoutCallout.swift
@@ -104,8 +104,8 @@ public class ExpressCheckoutCallout: _BaseEarnRedeemWidget {
         paymentStepLabel.attributedText = paymentStepString()
     }
 
-    override func createBenefitTextStyle() -> WidgetTextStyle {
-        return resolvedStyling?.widgetTextStyle ?? theme.widgetTextStyle(size: .regular)
+    override func createBenefitTextStyle() -> EarnRedeemLabelStyle {
+        return resolvedStyling?.earnRedeemLabelStyle() ?? theme.earnRedeemLabelStyle(size: .regular)
     }
 
     // MARK: - Autolayout
@@ -115,7 +115,7 @@ public class ExpressCheckoutCallout: _BaseEarnRedeemWidget {
         stack.axis = .vertical
         stack.alignment = .leading
         stack.distribution = .equalCentering
-        stack.spacing = UIConstant.smallSpacing
+        stack.spacing = resolvedStyling?.textStyle?.lineSpacing ?? UIConstant.smallSpacing
     }
 
     override public func layoutSubviews() {

--- a/Tests/CatchTests/Mock Objects/MockStyles.swift
+++ b/Tests/CatchTests/Mock Objects/MockStyles.swift
@@ -25,7 +25,7 @@ class MockStyles {
     // Widget styles
     static let localCalloutOverrides = InfoWidgetStyle(textStyle: overrideTextStyle,
                                                        benefitTextStyle: nil,
-                                                        infoButtonStyle: overrideTextStyle)
+                                                       infoButtonStyle: overrideTextStyle)
     static let localPurchaseConfirmationOverrides = ActionWidgetStyle(textStyle: overrideTextStyle,
                                                                       benefitTextStyle: nil,
                                                                       actionButtonStyle: overrideButtonStyle)

--- a/Tests/CatchTests/Mock Objects/MockStyles.swift
+++ b/Tests/CatchTests/Mock Objects/MockStyles.swift
@@ -23,15 +23,14 @@ class MockStyles {
     static let generalTextTransform: TextTransform = .uppercase
 
     // Widget styles
-    static let localCalloutOverrides = InfoWidgetStyle(widgetTextStyle: overrideTextStyles,
+    static let localCalloutOverrides = InfoWidgetStyle(textStyle: overrideTextStyle,
+                                                       benefitTextStyle: nil,
                                                         infoButtonStyle: overrideTextStyle)
-    static let localPurchaseConfirmationOverrides = ActionWidgetStyle(widgetTextStyle: overrideTextStyles,
+    static let localPurchaseConfirmationOverrides = ActionWidgetStyle(textStyle: overrideTextStyle,
+                                                                      benefitTextStyle: nil,
                                                                       actionButtonStyle: overrideButtonStyle)
 
     // Text styles
-    static let overrideTextStyles = WidgetTextStyle(textStyle: overrideTextStyle,
-                                                    benefitTextStyle: nil)
-
     static let generalTextStyle = TextStyle(font: generalFont,
                                             textColor: generalTextColor,
                                             textTransform: generalTextTransform,

--- a/Tests/CatchTests/StyleResolverTests.swift
+++ b/Tests/CatchTests/StyleResolverTests.swift
@@ -22,9 +22,9 @@ final class StyleResolverTests: XCTestCase {
                                                    globalOverrides: nil) as? InfoWidgetStyle
 
         XCTAssertNotNil(resolvedStyle, "The resolved style should be of type InfoWidgetStyle")
-        let textStyle = resolvedStyle?.widgetTextStyle?.textStyle
-        let overrideTextStyle = localOverrides.widgetTextStyle?.textStyle
-        let themeTextStyle = localTheme.styleDefaultForWidgetType(widgetType)?.widgetTextStyle?.textStyle
+        let textStyle = resolvedStyle?.textStyle
+        let overrideTextStyle = localOverrides.textStyle
+        let themeTextStyle = localTheme.styleDefaultForWidgetType(widgetType)?.textStyle
 
         let infoButtonStyle = resolvedStyle?.infoButtonStyle
         let overrideInfoButtonStyle = localOverrides.infoButtonStyle
@@ -84,9 +84,9 @@ final class StyleResolverTests: XCTestCase {
                                                    globalOverrides: globalCatchConfig) as? InfoWidgetStyle
 
         XCTAssertNotNil(resolvedStyle, "The resolved style should be of type InfoWidgetStyle")
-        let textStyle = resolvedStyle?.widgetTextStyle?.textStyle
-        let globalWidgetSpecificTextStyle = globalWidgetSpecificOverrides?.widgetTextStyle?.textStyle
-        let themeTextStyle = globalTheme.styleDefaultForWidgetType(widgetType)?.widgetTextStyle?.textStyle
+        let textStyle = resolvedStyle?.textStyle
+        let globalWidgetSpecificTextStyle = globalWidgetSpecificOverrides?.textStyle
+        let themeTextStyle = globalTheme.styleDefaultForWidgetType(widgetType)?.textStyle
 
         // Attributes which were defined in the widget-specific global overrides should exist in the resolved style
         XCTAssertEqual(textStyle?.font, globalWidgetSpecificTextStyle?.font)


### PR DESCRIPTION
### Summary
Refactors the text styling structs to remove `WidgetTextStyle` and place the `TextStyle` and `BenefitTextStyle` structs directly on the widget style structs. Removing this extra nesting will make text styling easier to configure and understand for the typical user.