### PR TITLE
Move order id into CreateVirtualCardCheckout body

### DIFF
--- a/Sources/Catch/Models/Catch.swift
+++ b/Sources/Catch/Models/Catch.swift
@@ -89,17 +89,13 @@ public class _Catch { // swiftlint:disable:this type_name
     }
 
     /**
-     Opens the virtual card checkout flow for a given order id.
-     - Parameter orderId: The ID of this order in the merchant's system which Catch will store
-     for shared identification purposes. This ID should be unique per order.
+     Create and opens the virtual card checkout flow.
      - Parameter checkoutData: The order data for the checkout.
      - Parameter options: Prefill values and callback functions for checkout confirmed or canceled.
      */
-    public func createAndOpenVirtualCardCheckout(orderId: String,
-                                                 checkoutData: CreateVirtualCardCheckoutBody,
+    public func createAndOpenVirtualCardCheckout(checkoutData: CreateVirtualCardCheckoutBody,
                                                  options: VirtualCardCheckoutOptions) {
         guard let webController = VirtualCardCheckoutController(
-            orderId: orderId,
             checkoutData: checkoutData,
             options: options) else { return }
         presentCheckoutController(webController)

--- a/Sources/Catch/Models/Checkout/CreateVirtualCardCheckoutBody.swift
+++ b/Sources/Catch/Models/Checkout/CreateVirtualCardCheckoutBody.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public struct CreateVirtualCardCheckoutBody: Codable {
     /// The ID of this order in the merchant's system which Catch will store
-    ///for shared identification purposes. This ID should be unique per order.
+    /// for shared identification purposes. This ID should be unique per order.
     let merchantOrderId: String
 
     /// The merchant's public API key.

--- a/Sources/Catch/Models/Checkout/CreateVirtualCardCheckoutBody.swift
+++ b/Sources/Catch/Models/Checkout/CreateVirtualCardCheckoutBody.swift
@@ -8,6 +8,10 @@
 import Foundation
 
 public struct CreateVirtualCardCheckoutBody: Codable {
+    /// The ID of this order in the merchant's system which Catch will store
+    ///for shared identification purposes. This ID should be unique per order.
+    let merchantOrderId: String
+
     /// The merchant's public API key.
     let merchantPublicKey: String
 
@@ -38,7 +42,8 @@ public struct CreateVirtualCardCheckoutBody: Codable {
     let userCohorts: [String]
 
     /// Initializes the data object which houses all parameters needed to create a virtual card checkout.
-    public init(merchantPublicKey: String,
+    public init(merchantOrderId: String,
+                merchantPublicKey: String,
                 amounts: Amounts,
                 billing: Address,
                 shipping: Address,
@@ -47,6 +52,7 @@ public struct CreateVirtualCardCheckoutBody: Codable {
                 merchantUserId: String,
                 platform: Platform?,
                 userCohorts: [String]) {
+        self.merchantOrderId = merchantOrderId
         self.merchantPublicKey = merchantPublicKey
         self.amounts = amounts
         self.billing = billing

--- a/Sources/Catch/Models/Checkout/VirtualCardCheckoutURLQuery.swift
+++ b/Sources/Catch/Models/Checkout/VirtualCardCheckoutURLQuery.swift
@@ -8,13 +8,12 @@
 import Foundation
 
 class VirtualCardCheckoutURLQuery: CheckoutURLQuery {
-    let orderId: String
+    /// Required query param to indicate this is a virtual card checkout
+    let integation: String = "vcn"
 
-    init(orderId: String,
-         prefill: CheckoutPrefill?,
+    init(prefill: CheckoutPrefill?,
          themeConfig: MerchantThemeConfig?,
          publicKey: String) {
-        self.orderId = orderId
         super.init(publicKey: publicKey, prefill: prefill, themeConfig: themeConfig)
     }
 }

--- a/Sources/Catch/Utilities/Enums/CatchURL.swift
+++ b/Sources/Catch/Utilities/Enums/CatchURL.swift
@@ -40,13 +40,11 @@ enum CatchURL {
         return checkoutURL(fromEncodableObject: directCheckoutQuery)
     }
 
-    static func virtualCardCheckout(orderId: String,
-                                    prefillFields: CheckoutPrefill?,
+    static func virtualCardCheckout(prefillFields: CheckoutPrefill?,
                                     merchantRepository: MerchantRepositoryInterface) -> URL? {
         guard let merchant = merchantRepository.getCurrentMerchant(),
               let publicKey = merchantRepository.merchantPublicKey else { return nil }
-        let virtualCardCheckoutQuery = VirtualCardCheckoutURLQuery(orderId: orderId,
-                                                                   prefill: prefillFields,
+        let virtualCardCheckoutQuery = VirtualCardCheckoutURLQuery(prefill: prefillFields,
                                                                    themeConfig: merchant.theme,
                                                                    publicKey: publicKey)
         return checkoutURL(fromEncodableObject: virtualCardCheckoutQuery)

--- a/Sources/Catch/Views/Components/Webviews/VirtualCardCheckoutController.swift
+++ b/Sources/Catch/Views/Components/Webviews/VirtualCardCheckoutController.swift
@@ -11,14 +11,12 @@ class VirtualCardCheckoutController: CheckoutController {
     var virtualCardCheckoutData: CreateVirtualCardCheckoutBody
     var options: VirtualCardCheckoutOptions?
 
-    init?(orderId: String,
-          checkoutData: CreateVirtualCardCheckoutBody,
+    init?(checkoutData: CreateVirtualCardCheckoutBody,
           options: VirtualCardCheckoutOptions?,
           merchantRepository: MerchantRepositoryInterface = Catch.merchantRepository) {
         self.virtualCardCheckoutData = checkoutData
         self.options = options
-        guard let url = CatchURL.virtualCardCheckout(orderId: orderId,
-                                                     prefillFields: options?.prefill,
+        guard let url = CatchURL.virtualCardCheckout(prefillFields: options?.prefill,
                                                      merchantRepository: merchantRepository) else { return nil }
         super.init(url: url, onCancel: options?.onCancel)
     }


### PR DESCRIPTION
### Summary
Small refactor of the way information is passed to create and open virtual card checkout.

**Previously:** 
`orderId` was passed in through the query params while a `CreateVirtualCardCheckoutBody` was post messaged up to `checkout-v2`.

**Now:** 
The order id (now named `merchantOrderId`) is post messaged along with the rest of the fields in `CreateVirtualCardCheckoutBody`.

This also adds a new query param `integration="vcn"` as required by checkout-v2 to identify the checkout's type.

### Depends on
https://github.com/getcatch/checkout-v2/pull/303
https://github.com/getcatch/catch-frontend-common/pull/383
https://github.com/getcatch/catchjs-sdk/pull/194
Swiftlint update dependency: https://github.com/getcatch/catch-ios-sdk/pull/83