### PR TITLE
Refresh merchant and public user data when application becomes active

### DIFF
--- a/Sources/Catch/Data/MerchantRepository.swift
+++ b/Sources/Catch/Data/MerchantRepository.swift
@@ -13,7 +13,7 @@ protocol MerchantRepositoryInterface {
     func fetchMerchant(from merchantPublicKey: String, completion: @escaping (Result<Bool, Error>) -> Void)
 }
 
-class MerchantRepository: MerchantRepositoryInterface {
+class MerchantRepository: MerchantRepositoryInterface, NotificationResponding {
 
     internal var merchantPublicKey: String?
     private var merchant: Merchant? {
@@ -34,6 +34,7 @@ class MerchantRepository: MerchantRepositoryInterface {
         self.networkService = networkService
         self.cache = cache
         self.notificationCenter = notificationCenter
+        subscribeToApplicationDidBecomeActiveNotification()
     }
 
     func getCurrentMerchant() -> Merchant? {
@@ -63,5 +64,18 @@ class MerchantRepository: MerchantRepositoryInterface {
                 }
             }
         }
+    }
+
+    internal func didReceiveNotification(_ notification: Notification) {
+        guard notification.name == NotificationName.applicationDidBecomeActive else {
+            Logger.log("MerchantRepository received unknown notification named: \(notification.name)")
+            return
+        }
+        refreshMerchant()
+    }
+
+    private func refreshMerchant() {
+        guard let publicKey = merchantPublicKey else { return }
+        fetchMerchant(from: publicKey, completion: {_ in })
     }
 }

--- a/Sources/Catch/Data/MerchantRepository.swift
+++ b/Sources/Catch/Data/MerchantRepository.swift
@@ -78,4 +78,8 @@ class MerchantRepository: MerchantRepositoryInterface, NotificationResponding {
         guard let publicKey = merchantPublicKey else { return }
         fetchMerchant(from: publicKey, completion: {_ in })
     }
+
+    deinit {
+        unsubscribeFromNotifications()
+    }
 }

--- a/Sources/Catch/Data/UserRepository.swift
+++ b/Sources/Catch/Data/UserRepository.swift
@@ -94,4 +94,8 @@ class UserRepository: UserRepositoryInterface, NotificationResponding {
         }
         fetchUserData(merchantId: merchantId)
     }
+
+    deinit {
+        unsubscribeFromNotifications()
+    }
 }

--- a/Sources/Catch/Utilities/Enums/NotificationName.swift
+++ b/Sources/Catch/Utilities/Enums/NotificationName.swift
@@ -5,7 +5,7 @@
 //  Created by Lucille Benoit on 10/18/22.
 //
 
-import Foundation
+import UIKit
 
 enum NotificationName {
     static let publicUserDataUpdate = Notification.Name("PublicUserDataUpdate")

--- a/Sources/Catch/Utilities/Enums/NotificationName.swift
+++ b/Sources/Catch/Utilities/Enums/NotificationName.swift
@@ -11,4 +11,5 @@ enum NotificationName {
     static let publicUserDataUpdate = Notification.Name("PublicUserDataUpdate")
     static let globalThemeUpdate = Notification.Name("GlobalThemeUpdate")
     static let merchantUpdate = Notification.Name("MerchantUpdate")
+    static let applicationDidBecomeActive = UIApplication.didBecomeActiveNotification
 }

--- a/Sources/Catch/Views/ViewModels/NotificationResponding.swift
+++ b/Sources/Catch/Views/ViewModels/NotificationResponding.swift
@@ -35,6 +35,10 @@ extension NotificationResponding {
         subscribeToNotifications(notifications: [NotificationName.merchantUpdate])
     }
 
+    func subscribeToApplicationDidBecomeActiveNotification() {
+        subscribeToNotifications(notifications: [NotificationName.applicationDidBecomeActive])
+    }
+
     func subscribeToNotifications(notifications: [Notification.Name]) {
         for notification in notifications {
             let token = NotificationCenter.default.addObserver(forName: notification,


### PR DESCRIPTION
### Summary
Per Clark's idea ([Android PR](https://github.com/getcatch/catch-android-sdk/pull/92)), adds a refresh of `PublicUserData` and `Merchant` whenever the application becomes active.

The app is active after being launched, loses that active status when an overlay window pops up or when the device is locked, and regains active status when the app reappears or device is unlocked.

Swiftlint update dependency: https://github.com/getcatch/catch-ios-sdk/pull/83