### PR TITLE
Support iPad Multiple Scenes

### DIFF
--- a/Sources/Catch/Utilities/UIApplication+Extension.swift
+++ b/Sources/Catch/Utilities/UIApplication+Extension.swift
@@ -9,12 +9,22 @@ import UIKit
 
 extension UIApplication {
     static func topViewController() -> UIViewController? {
-        guard var top = shared.keyWindow?.rootViewController else {
-            return nil
+        var topViewController: UIViewController?
+
+        if #available(iOS 13.0, *) {
+            let keyWindow = shared
+                .connectedScenes
+                .flatMap { ($0 as? UIWindowScene)?.windows ?? [] }
+                .last { $0.isKeyWindow }
+            topViewController = keyWindow?.rootViewController
+        } else {
+            topViewController = shared.keyWindow?.rootViewController
         }
-        while let next = top.presentedViewController {
-            top = next
+
+        while let presentedViewController = topViewController?.presentedViewController {
+            topViewController = presentedViewController
         }
-        return top
+
+        return topViewController
     }
 }


### PR DESCRIPTION
### Summary

This PR adds support for iPads with multiple scenes in the `UIApplication` extension. With the introduction of multiple scenes in iOS 13, iPads can have multiple windows and view controllers, requiring adjustments to the existing code.

To handle iPads with multiple scenes, the `topViewController()` method in the `UIApplication` extension has been updated. The changes ensure that the topmost view controller is correctly determined, taking into account both the primary scene and additional connected scenes.