### PR TITLE
Add new tofu post message to support lazy loading changes

### DIFF
--- a/Example/Example/Utils/OrderedDictionary.swift
+++ b/Example/Example/Utils/OrderedDictionary.swift
@@ -14,8 +14,6 @@ struct OrderedDictionary<Tk: Hashable, Tv> {
     var keys: [Tk] = []
     var values: [Tk: Tv] = [:]
 
-    init() {}
-
     subscript(key: Tk) -> Tv? {
         get {
             return self.values[key]

--- a/Sources/Catch/Utilities/Strings/StringFormat.swift
+++ b/Sources/Catch/Utilities/Strings/StringFormat.swift
@@ -88,7 +88,7 @@ extension NumberFormatter {
         let formatter = NumberFormatter()
         formatter.usesGroupingSeparator = true
         formatter.numberStyle = .currency
-        formatter.locale = Locale.current
+        formatter.locale = Locale(identifier: "en_US")
         return formatter
     }
 

--- a/Sources/Catch/Utilities/WebViews/PostMessageAction.swift
+++ b/Sources/Catch/Utilities/WebViews/PostMessageAction.swift
@@ -8,6 +8,8 @@
 import Foundation
 
 enum PostMessageAction: String {
+    case tofuListening = "CATCH_TOFU_LISTENING"
+    case tofuLoad = "CATCH_TOFU_LOAD"
     case tofuReady = "CATCH_TOFU_READY"
     case tofuOpen = "CATCH_TOFU_OPEN"
     case tofuBack = "CATCH_TOFU_BACK"

--- a/Sources/Catch/Views/Components/Webviews/TofuController.swift
+++ b/Sources/Catch/Views/Components/Webviews/TofuController.swift
@@ -31,12 +31,15 @@ class TofuController: CatchWebViewController, PostMessageHandler {
 
     func handlePostMessage(_ postMessage: PostMessageAction, data: Any? = nil) {
         switch postMessage {
-        case .tofuReady:
-            let sendTofuData: JSScript = .postMessage(action: .tofuOpen, dataObject: tofuOpenData)
-            webView.evaluateScript(sendTofuData)
-        case .tofuBack:
-            dismiss(animated: true)
-        default: ()
+            case .tofuListening:
+                let tofuLoadData: JSScript = .postMessage(action: .tofuLoad, dataObject: [:])
+                webView.evaluateScript(tofuLoadData)
+            case .tofuReady:
+                let sendTofuData: JSScript = .postMessage(action: .tofuOpen, dataObject: tofuOpenData)
+                webView.evaluateScript(sendTofuData)
+            case .tofuBack:
+                dismiss(animated: true)
+            default: ()
         }
     }
 


### PR DESCRIPTION
### Summary

- Adds support for two new tofu post messages: `CATCH_TOFU_LISTENING` and `CATCH_TOFU_LOAD`.
- Formats all price currencies using the en-US locale